### PR TITLE
storage/index.md: bind mounts must use absolute paths

### DIFF
--- a/storage/index.md
+++ b/storage/index.md
@@ -78,8 +78,8 @@ mounts is to think about where the data lives on the Docker host.
 - **[Bind mounts](bind-mounts.md)**: Available since the early days of Docker.
   Bind mounts have limited functionality compared to volumes. When you use a
   bind mount, a file or directory on the _host machine_ is mounted into a
-  container. The file or directory is referenced by its full path on the host
-  machine. The file or directory does not need to exist on the Docker host
+  container. The file or directory must be referenced by its full path on the host
+  machine, or else it will silently fail. The file or directory does not need to exist on the Docker host
   already. It is created on demand if it does not yet exist. Bind mounts are
   very performant, but they rely on the host machine's filesystem having a
   specific directory structure available. If you are developing new Docker


### PR DESCRIPTION
Clarified that bind mounts *must* use absolute paths, else they will silently "fail" (have unexpected behavior).

References:
https://github.com/moby/moby/issues/4830#issuecomment-404242401
https://github.com/docker/cli/issues/1203

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
